### PR TITLE
Moved out handling of command line arguments #23

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ endif()
 
 add_executable(R2F-MessengerServer
     include/BackEnd.h
+    include/CommandLineOptions.h
     include/ConnectedClientManager.h
     include/Database.h
     include/Logger.h
@@ -43,12 +44,12 @@ add_executable(R2F-MessengerServer
     include/ServerManager.h
     include/SessionKey.h
     include/server.h
-    include/stdafx.h
     include/messagecode.h
     include/TcpDumpManager.h
     include/PacketAnalyzer.h
 
     src/BackEnd.cpp
+    src/CommandLineOptions.cpp
     src/ConnectedClientManager.cpp
     src/Database.cpp
     src/MessageProcessor.cpp
@@ -58,8 +59,6 @@ add_executable(R2F-MessengerServer
     src/server.cpp
     src/TcpDumpManager.cpp
     src/PacketAnalyzer.cpp
-
-    ${QT_RESOURCES}
 )
 
 target_link_options(R2F-MessengerServer PRIVATE -v)
@@ -81,7 +80,10 @@ if(CMAKE_BUILD_TYPE MATCHES "Debug")
     )
 endif()
 
-target_include_directories(R2F-MessengerServer PRIVATE ${GMP_INCLUDE_DIR})
+target_include_directories(R2F-MessengerServer PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+    ${GMP_INCLUDE_DIR}
+)
 target_link_libraries(R2F-MessengerServer PRIVATE
    ${GMP_LIBRARY}
 )

--- a/include/BackEnd.h
+++ b/include/BackEnd.h
@@ -1,9 +1,7 @@
 #pragma once
 
-#include "stdafx.h"
-
-#include "ServerManager.h"
 #include "Logger.h"
+#include "ServerManager.h"
 
 class BackEnd : public QObject
 {

--- a/include/CommandLineOptions.h
+++ b/include/CommandLineOptions.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "Logger.h"
+
+#include <QCommandLineParser>
+
+#include <memory>
+
+enum LogOption { NoLog, ConsoleLog, FileLog, NoOption };
+
+class CommandLineOptions {
+public:
+    explicit CommandLineOptions();
+    void parse();
+    std::shared_ptr<ILogger> createLogger() const;
+
+private:
+    QCommandLineParser parser;
+    LogOption logOption_;
+};

--- a/include/Database.h
+++ b/include/Database.h
@@ -1,13 +1,8 @@
 #pragma once
 
-#include "stdafx.h"
-#include <QMap>
-#include <optional>
+#include <QJsonObject>
 
-#include <QSqlDatabase>
-#include <QSqlError>
-#include <QSqlQuery>
-#include <QSqlQueryModel>
+#include <optional>
 
 struct Identification_request
 {
@@ -33,7 +28,8 @@ class Database: public QObject
     Q_OBJECT
 
 public:
-    Database();
+    explicit Database( QObject *parent = nullptr );
+    ~Database() {}
 
     Identification_request registration( const QString &login, const QString& password );
     Identification_request authorization( const QString &login, const QString &password );

--- a/include/MessageProcessor.h
+++ b/include/MessageProcessor.h
@@ -6,7 +6,6 @@
 #include "SessionKey.h"
 
 #include <QTcpSocket>
-#include <QCryptographicHash>
 #include <QJsonObject>
 #include <QList>
 
@@ -17,7 +16,7 @@ class MessageProcessor: public QObject
     Q_OBJECT
 
 public:
-    MessageProcessor();
+    explicit MessageProcessor(QObject *parent = nullptr);
     ~MessageProcessor();
     void processIncomingMessages(const QJsonObject& obj, QTcpSocket* clientSocket);
     void processUserDisconnection(QTcpSocket* disconnected_user_socket);

--- a/include/PacketAnalyzer.h
+++ b/include/PacketAnalyzer.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QString>
+
 #include <vector>
 
 struct Packet {

--- a/include/ServerManager.h
+++ b/include/ServerManager.h
@@ -2,6 +2,9 @@
 
 #include "server.h"
 
+#include <QJsonObject>
+#include <QTcpSocket>
+
 #include <atomic>
 #include <condition_variable>
 #include <mutex>
@@ -10,15 +13,12 @@
 #include <thread>
 #include <vector>
 
-#include <QJsonObject>
-#include <QTcpSocket>
-
 class ServerManager: public QObject
 {
     Q_OBJECT
 
 public:
-    ServerManager();
+    explicit ServerManager( QObject *parent = nullptr );
     ~ServerManager();
     QString startServer();
     QString stopServer();
@@ -31,7 +31,7 @@ public slots:
 
 signals:
     void smbConnected_signal();
-    void gotNewMesssage_signal( QString msg );
+    void gotNewMesssage_signal( QString message );
     void smbDisconnected_signal();
 
 private:

--- a/include/SessionKey.h
+++ b/include/SessionKey.h
@@ -1,5 +1,5 @@
 #pragma once
-#include "stdafx.h"
+
 #include <ctime>
 #include <math.h>
 

--- a/include/TcpDumpManager.h
+++ b/include/TcpDumpManager.h
@@ -1,11 +1,11 @@
 #pragma once
 
+#include "PacketAnalyzer.h"
+
 #include <QObject>
 #include <QProcess>
 
 #include <memory>
-
-#include "PacketAnalyzer.h"
 
 class TcpDumpManager : public QObject
 {

--- a/include/server.h
+++ b/include/server.h
@@ -1,12 +1,11 @@
 #pragma once
 
-#include "stdafx.h"
 #include "messagecode.h"
 #include "MessageProcessor.h"
 
+#include <QJsonObject>
 #include <QTcpServer>
 #include <QTcpSocket>
-#include <QJsonObject>
 
 class Server: public QObject
 {

--- a/include/stdafx.h
+++ b/include/stdafx.h
@@ -1,9 +1,0 @@
-#pragma once
-
-#include <QString>
-#include <QSqlDatabase>
-#include <QSqlQuery>
-#include <QJsonObject>
-#include <QJsonParseError>
-#include <QDebug>
-#include <QJsonArray>

--- a/src/BackEnd.cpp
+++ b/src/BackEnd.cpp
@@ -1,15 +1,15 @@
+#include "BackEnd.h"
+
 #include <QString>
 
-#include "../include/ServerManager.h"
-#include "../include/BackEnd.h"
-
 BackEnd::BackEnd( std::shared_ptr< ILogger > logger, QObject *parent )
-    : QObject{ parent }
-    , serverManager_{ std::make_unique< ServerManager >() }
+    : QObject( parent )
+    , serverManager_( std::make_unique< ServerManager >() )
     , logger_( logger )
 {
     serverManager_->startServer();
     qDebug() << "Server started";
+    logger_->log(LogLevel::INFO, "Server started");
 
     connect( serverManager_.get(), &ServerManager::gotNewMesssage_signal, this, &BackEnd::gotNewMesssage );
     connect( serverManager_.get(), &ServerManager::smbConnected_signal, this, &BackEnd::smbConnectedToServer );

--- a/src/CommandLineOptions.cpp
+++ b/src/CommandLineOptions.cpp
@@ -1,0 +1,63 @@
+﻿#include "CommandLineOptions.h"
+
+#include <QDebug>
+
+CommandLineOptions::CommandLineOptions() {
+    parser.setApplicationDescription("QCommandLineParser");
+    parser.addHelpOption();
+
+    parser.addOption({{"n", "no-log"}, "Disable logging."});
+    parser.addOption({{"c", "console-log"}, "Log to console."});
+    parser.addOption({{"f", "file-log"}, "Log to file."});
+
+    parser.process(QCoreApplication::arguments());
+}
+
+void CommandLineOptions::parse() {
+    const bool noLog = parser.isSet("no-log");
+    const bool consoleLog = parser.isSet("console-log");
+    const bool fileLog = parser.isSet("file-log");
+
+    const int8_t selectedOptions = noLog + consoleLog + fileLog;
+
+    if (selectedOptions == 0) {
+        logOption_ = LogOption::NoOption;
+    }
+    else if (noLog == true && selectedOptions > 1) {
+        qDebug() << "You selected no logging and another logging type, "
+                    "the no logging type will be set.";
+        logOption_ = LogOption::NoLog;
+    }
+    else if (selectedOptions > 1 ) {        
+        qDebug() << "You have selected several types of logging, "
+                    "so only file logging will be selected as default.";
+        logOption_ = LogOption::FileLog;
+    }
+    else if (fileLog) {
+        qDebug() << "Logging to file.";
+        logOption_ = LogOption::FileLog;
+    }
+    else if (consoleLog) {
+        qDebug() << "Logging to console.";
+        logOption_ = LogOption::ConsoleLog;
+    }
+    else if (noLog) {
+        qDebug() << "Logging is disabled.";
+        logOption_ = LogOption::NoLog;
+    }
+    else {
+        qDebug() << "No specific logging option set. Logging is disabled.";
+    }
+}
+
+std::shared_ptr<ILogger> CommandLineOptions::createLogger() const {
+    if (logOption_ == LogOption::NoLog) {
+        return nullptr;
+    } else if (logOption_ == LogOption::FileLog) {        
+        return std::make_shared<FileLogger>();
+    } else if (logOption_ == LogOption::ConsoleLog) {
+        return std::make_shared<ConsoleLogger>();
+    } else {
+        return nullptr;
+    }
+}

--- a/src/ConnectedClientManager.cpp
+++ b/src/ConnectedClientManager.cpp
@@ -1,4 +1,4 @@
-#include "../include/ConnectedClientManager.h"
+#include "ConnectedClientManager.h"
 
 void ConnectedClientManager::addNewClientSocket( QTcpSocket *socket )
 {

--- a/src/Database.cpp
+++ b/src/Database.cpp
@@ -1,11 +1,8 @@
-#include "../include/Database.h"
+#include "Database.h"
 
 #include <QSqlDatabase>
 #include <QSqlError>
 #include <QSqlQuery>
-#include <QSqlQueryModel>
-
-#include <optional>
 
 static void connectToDatabase()
 {
@@ -33,8 +30,8 @@ static void createTable()
     qDebug() << __FILE__ << __LINE__ << "Table is created";
 }
 
-Database::Database()
-    : QObject()
+Database::Database( QObject *parent )
+    : QObject( parent )
 {
     connectToDatabase();
     createTable();

--- a/src/MessageProcessor.cpp
+++ b/src/MessageProcessor.cpp
@@ -1,8 +1,11 @@
-#include "../include/MessageProcessor.h"
+#include "MessageProcessor.h"
 
-MessageProcessor::MessageProcessor()
-    : QObject()
-    {}
+#include <QCryptographicHash>
+#include <QJsonParseError>
+
+MessageProcessor::MessageProcessor(QObject *parent)
+    : QObject( parent )
+{}
 
 MessageProcessor::~MessageProcessor()
 {

--- a/src/PacketAnalyzer.cpp
+++ b/src/PacketAnalyzer.cpp
@@ -1,9 +1,9 @@
-#include "../include/PacketAnalyzer.h"
+#include "PacketAnalyzer.h"
 
 #include <QDebug>
-#include <regex>
-#include <iostream>
 
+#include <iostream>
+#include <regex>
 
 std::vector<std::string> PacketAnalyzer::splitPackets(const std::string& packets) {
     std::vector<std::string> packet_list;

--- a/src/ServerManager.cpp
+++ b/src/ServerManager.cpp
@@ -1,7 +1,7 @@
-#include "../include/ServerManager.h"
+#include "ServerManager.h"
 
-ServerManager::ServerManager()
-    : QObject()
+ServerManager::ServerManager(QObject *parent)
+    : QObject( parent )
     , server_( std::make_unique< Server >() )
     , done_ ( false )
 {

--- a/src/SessionKey.cpp
+++ b/src/SessionKey.cpp
@@ -1,4 +1,6 @@
-#include "../include/SessionKey.h"
+#include "SessionKey.h"
+
+#include <QString>
 
 SessionKey::SessionKey()
 {

--- a/src/TcpDumpManager.cpp
+++ b/src/TcpDumpManager.cpp
@@ -1,4 +1,4 @@
-#include "../include/TcpDumpManager.h"
+#include "TcpDumpManager.h"
 
 #include <QDebug>
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,47 +1,20 @@
+#include "BackEnd.h"
+#include "CommandLineOptions.h"
+#include "Logger.h"
+#include "TcpDumpManager.h"
+
 #include <QCoreApplication>
 #include <QCommandLineParser>
-
-#include "../include/BackEnd.h"
-#include "../include/Logger.h"
-#include "../include/TcpDumpManager.h"
 
 int main( int argc, char *argv[] )
 {
     QCoreApplication::setAttribute( Qt::AA_EnableHighDpiScaling );
     QCoreApplication app(argc, argv);
 
-    // Create the command-line parser
-    QCommandLineParser parser;
-    parser.setApplicationDescription("Test QCommandLineParser");
-    parser.addHelpOption(); // Adds --help option by default
+    CommandLineOptions options;
+    options.parse();
 
-    // Define options (command-line flags)
-    QCommandLineOption noLogOption(QStringList() << "n" << "no-log", "Disable logging.");
-    QCommandLineOption consoleLogOption(QStringList() << "c" << "console-log", "Log to console.");
-    QCommandLineOption logFileOption(QStringList() << "f" << "file-log", "Log to file.");
-
-    // Add options to the parser
-    parser.addOption(noLogOption);
-    parser.addOption(consoleLogOption);
-    parser.addOption(logFileOption);
-
-    // Process the actual command-line arguments given by the user
-    parser.process(app);
-
-    std::shared_ptr< ILogger > logger;
-
-    // Handle the command-line options
-    if (parser.isSet(noLogOption)) {
-        qDebug() << "Logging is disabled.";
-    } else if (parser.isSet(consoleLogOption)) {
-        qDebug() << "Logging to console.";
-        logger = std::make_shared< ConsoleLogger >();
-    } else if (parser.isSet(logFileOption)) {
-        qDebug() << "Logging to file (default).";
-        logger = std::make_shared< FileLogger > ( "/var/log/myapp/application.log" );
-    } else {
-        qDebug() << "No specific logging option set. Logging is disabled.";
-    }
+    std::shared_ptr< ILogger > logger = options.createLogger();
 
     BackEnd backEnd( logger );
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1,5 +1,7 @@
-#include "../include/Database.h"
-#include "../include/server.h"
+#include "Database.h"
+#include "server.h"
+
+#include <QJsonParseError>
 
 #include <memory>
 


### PR DESCRIPTION
- moved command line arguments to CommandLineOptions class
- changes in CMakeLists.txt
- simplified the order of writing path to include files
- synchronized the order of including files in *.cpp
- removed stdafx.h
- set to a standard form constructors of classes inherited from QObject
- logger changes:
- made the Filelogger file name unique

Issue: Server #20